### PR TITLE
Feat: Add support for optional arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,35 @@ message Widget {
 }
 ```
 
+* `nullable_arrays` - if set to true (default false), arrays are mapped to union of null. E.g. :
+
+```protobuf
+message StringList {
+  repeated string strings = 1;
+}
+```
+
+...the output will look like:
+
+```json
+{
+  "type": "record",
+  "name": "StringList",
+  "fields": [
+    {
+      "name": "strings",
+      "type": [
+        "null",
+        {
+          "type": "array",
+          "items": "string"
+        }
+      ],
+      "default": null
+    }
+  ]
+}
+```
 
 ---
 

--- a/avro/field.go
+++ b/avro/field.go
@@ -54,7 +54,11 @@ func FieldFromProto(proto *descriptorpb.FieldDescriptorProto, typeRepo *TypeRepo
 func FieldTypeFromProto(proto *descriptorpb.FieldDescriptorProto, typeRepo *TypeRepo) Type {
 	basicType := BasicFieldTypeFromProto(proto)
 	if proto.GetLabel() == descriptorpb.FieldDescriptorProto_LABEL_REPEATED {
-		return Array{Items: basicType}
+		if typeRepo.NullableArrays {
+			return Union{Types: []Type{Bare("null"), Array{Items: basicType}}}
+		} else {
+			return Array{Items: basicType}
+		}
 	} else if proto.GetProto3Optional() || (proto.OneofIndex != nil && typeRepo.RetainOneofFieldnames) {
 		return Union{Types: []Type{Bare("null"), basicType}}
 	} else {

--- a/avro/typeRepo.go
+++ b/avro/typeRepo.go
@@ -16,6 +16,7 @@ type TypeRepo struct {
   PreserveNonStringMaps bool
   JsonFieldnames bool
   RetainOneofFieldnames bool
+  NullableArrays bool
 }
 
 func NewTypeRepo(params input.Params) *TypeRepo {
@@ -27,6 +28,7 @@ func NewTypeRepo(params input.Params) *TypeRepo {
     PreserveNonStringMaps: params.PreserveNonStringMaps,
     JsonFieldnames: params.JsonFieldnames,
     RetainOneofFieldnames: params.RetainOneofFieldnames,
+    NullableArrays: params.NullableArrays,
   }
 }
 

--- a/input/params.go
+++ b/input/params.go
@@ -17,6 +17,7 @@ type Params struct {
 	PrefixSchemaFilesWithPackage bool
 	JsonFieldnames               bool
 	RetainOneofFieldnames        bool
+	NullableArrays               bool
 }
 
 func ReadRequest() (*pluginpb.CodeGeneratorRequest, error) {
@@ -74,6 +75,8 @@ func ParseParams(req *pluginpb.CodeGeneratorRequest) Params {
 			params.JsonFieldnames = true
 		} else if k == "retain_oneof_fieldnames" {
 			params.RetainOneofFieldnames = true
+		} else if k == "nullable_arrays" {
+			params.NullableArrays = true
 		}
 	}
 	return params

--- a/main_test.go
+++ b/main_test.go
@@ -117,6 +117,10 @@ func Test_RetainOneofFieldnames_JsonFieldnames(t *testing.T) {
   runTest(t, "retain_oneof_fieldnames_json_fieldnames", map[string]string{"retain_oneof_fieldnames": "true", "json_fieldnames": "true"})
 }
 
+func Test_NullableArrays(t *testing.T) {
+	runTest(t, "nullable_arrays", map[string]string{"nullable_arrays": "true"})
+}
+
 func assertEqualFiles(t *testing.T, original, generated string) {
 	names, err := fileNames(original, false, true)
 	if err != nil {

--- a/testdata/nullable_arrays/AOneOf.avsc
+++ b/testdata/nullable_arrays/AOneOf.avsc
@@ -1,0 +1,37 @@
+{
+  "type": "record",
+  "name": "AOneOf",
+  "namespace": "testdata",
+  "fields": [
+    {
+      "name": "oneof_types",
+      "type": [
+        {
+          "type": "record",
+          "name": "TypeA",
+          "namespace": "testdata",
+          "fields": [
+            {
+              "name": "foo",
+              "type": "string",
+              "default": ""
+            }
+          ]
+        },
+        {
+          "type": "record",
+          "name": "TypeB",
+          "namespace": "testdata",
+          "fields": [
+            {
+              "name": "bar",
+              "type": "string",
+              "default": ""
+            }
+          ]
+        }
+      ],
+      "default": null
+    }
+  ]
+}

--- a/testdata/nullable_arrays/Foobar.avsc
+++ b/testdata/nullable_arrays/Foobar.avsc
@@ -1,0 +1,188 @@
+{
+  "type": "record",
+  "name": "Foobar",
+  "namespace": "testdata",
+  "fields": [
+    {
+      "name": "name",
+      "type": "string",
+      "default": ""
+    },
+    {
+      "name": "blarp",
+      "type": {
+        "type": "enum",
+        "name": "Blarp",
+        "symbols": [
+          "BLARP_UNSPECIFIED",
+          "BLARP_ME",
+          "BLARP_YOU"
+        ],
+        "default": "BLARP_UNSPECIFIED"
+      },
+      "default": "BLARP_UNSPECIFIED"
+    },
+    {
+      "name": "yowza",
+      "type": {
+        "type": "record",
+        "name": "Yowza",
+        "namespace": "testdata",
+        "fields": [
+          {
+            "name": "hoo_boy",
+            "type": "float",
+            "default": 0
+          }
+        ]
+      }
+    },
+    {
+      "name": "blarps",
+      "type": [
+        "null",
+        {
+          "type": "array",
+          "items": "testdata.Blarp"
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "yowzas",
+      "type": [
+        "null",
+        {
+          "type": "array",
+          "items": "testdata.Yowza"
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "names",
+      "type": [
+        "null",
+        {
+          "type": "array",
+          "items": "string"
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "optional_name",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "optional_blarp",
+      "type": [
+        "null",
+        "testdata.Blarp"
+      ],
+      "default": null
+    },
+    {
+      "name": "optional_yowza",
+      "type": [
+        "null",
+        "testdata.Yowza"
+      ],
+      "default": null
+    },
+    {
+      "name": "a_num",
+      "type": "int",
+      "default": 0
+    },
+    {
+      "name": "a_string_map",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": "string"
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "a_blarp_map",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": "testdata.Blarp"
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "a_yowza_map",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": "testdata.Yowza"
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "string_list_map",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": {
+            "type": "record",
+            "name": "StringList",
+            "namespace": "testdata",
+            "fields": [
+              {
+                "name": "data",
+                "type": [
+                  "null",
+                  {
+                    "type": "array",
+                    "items": "string"
+                  }
+                ],
+                "default": null
+              }
+            ]
+          }
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "string_lists",
+      "type": [
+        "null",
+        {
+          "type": "array",
+          "items": "testdata.StringList"
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "nested_enum",
+      "type": {
+        "type": "enum",
+        "name": "NestedEnum",
+        "symbols": [
+          "A",
+          "B"
+        ],
+        "default": "A"
+      },
+      "default": "A"
+    }
+  ]
+}

--- a/testdata/nullable_arrays/StringList.avsc
+++ b/testdata/nullable_arrays/StringList.avsc
@@ -1,0 +1,18 @@
+{
+  "type": "record",
+  "name": "StringList",
+  "namespace": "testdata",
+  "fields": [
+    {
+      "name": "data",
+      "type": [
+        "null",
+        {
+          "type": "array",
+          "items": "string"
+        }
+      ],
+      "default": null
+    }
+  ]
+}

--- a/testdata/nullable_arrays/TypeA.avsc
+++ b/testdata/nullable_arrays/TypeA.avsc
@@ -1,0 +1,12 @@
+{
+  "type": "record",
+  "name": "TypeA",
+  "namespace": "testdata",
+  "fields": [
+    {
+      "name": "foo",
+      "type": "string",
+      "default": ""
+    }
+  ]
+}

--- a/testdata/nullable_arrays/TypeB.avsc
+++ b/testdata/nullable_arrays/TypeB.avsc
@@ -1,0 +1,12 @@
+{
+  "type": "record",
+  "name": "TypeB",
+  "namespace": "testdata",
+  "fields": [
+    {
+      "name": "bar",
+      "type": "string",
+      "default": ""
+    }
+  ]
+}

--- a/testdata/nullable_arrays/Widget.avsc
+++ b/testdata/nullable_arrays/Widget.avsc
@@ -1,0 +1,271 @@
+{
+  "type": "record",
+  "name": "Widget",
+  "namespace": "testdata",
+  "fields": [
+    {
+      "name": "from_date",
+      "type": [
+        "null",
+        "long"
+      ],
+      "default": null
+    },
+    {
+      "name": "to_date",
+      "type": "long",
+      "default": 0
+    },
+    {
+      "name": "string_map",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": {
+            "type": "record",
+            "name": "StringList",
+            "namespace": "testdata",
+            "fields": [
+              {
+                "name": "data",
+                "type": [
+                  "null",
+                  {
+                    "type": "array",
+                    "items": "string"
+                  }
+                ],
+                "default": null
+              }
+            ]
+          }
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "strings",
+      "type": "testdata.StringList",
+      "default": ""
+    },
+    {
+      "name": "a_one_of",
+      "type": [
+        "null",
+        {
+          "type": "record",
+          "name": "AOneOf",
+          "namespace": "testdata",
+          "fields": [
+            {
+              "name": "oneof_types",
+              "type": [
+                {
+                  "type": "record",
+                  "name": "TypeA",
+                  "namespace": "testdata",
+                  "fields": [
+                    {
+                      "name": "foo",
+                      "type": "string",
+                      "default": ""
+                    }
+                  ]
+                },
+                {
+                  "type": "record",
+                  "name": "TypeB",
+                  "namespace": "testdata",
+                  "fields": [
+                    {
+                      "name": "bar",
+                      "type": "string",
+                      "default": ""
+                    }
+                  ]
+                }
+              ],
+              "default": null
+            }
+          ]
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "foobar",
+      "type": {
+        "type": "record",
+        "name": "Foobar",
+        "namespace": "testdata",
+        "fields": [
+          {
+            "name": "name",
+            "type": "string",
+            "default": ""
+          },
+          {
+            "name": "blarp",
+            "type": {
+              "type": "enum",
+              "name": "Blarp",
+              "symbols": [
+                "BLARP_UNSPECIFIED",
+                "BLARP_ME",
+                "BLARP_YOU"
+              ],
+              "default": "BLARP_UNSPECIFIED"
+            },
+            "default": "BLARP_UNSPECIFIED"
+          },
+          {
+            "name": "yowza",
+            "type": {
+              "type": "record",
+              "name": "Yowza",
+              "namespace": "testdata",
+              "fields": [
+                {
+                  "name": "hoo_boy",
+                  "type": "float",
+                  "default": 0
+                }
+              ]
+            }
+          },
+          {
+            "name": "blarps",
+            "type": [
+              "null",
+              {
+                "type": "array",
+                "items": "testdata.Blarp"
+              }
+            ],
+            "default": null
+          },
+          {
+            "name": "yowzas",
+            "type": [
+              "null",
+              {
+                "type": "array",
+                "items": "testdata.Yowza"
+              }
+            ],
+            "default": null
+          },
+          {
+            "name": "names",
+            "type": [
+              "null",
+              {
+                "type": "array",
+                "items": "string"
+              }
+            ],
+            "default": null
+          },
+          {
+            "name": "optional_name",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          },
+          {
+            "name": "optional_blarp",
+            "type": [
+              "null",
+              "testdata.Blarp"
+            ],
+            "default": null
+          },
+          {
+            "name": "optional_yowza",
+            "type": [
+              "null",
+              "testdata.Yowza"
+            ],
+            "default": null
+          },
+          {
+            "name": "a_num",
+            "type": "int",
+            "default": 0
+          },
+          {
+            "name": "a_string_map",
+            "type": [
+              "null",
+              {
+                "type": "map",
+                "values": "string"
+              }
+            ],
+            "default": null
+          },
+          {
+            "name": "a_blarp_map",
+            "type": [
+              "null",
+              {
+                "type": "map",
+                "values": "testdata.Blarp"
+              }
+            ],
+            "default": null
+          },
+          {
+            "name": "a_yowza_map",
+            "type": [
+              "null",
+              {
+                "type": "map",
+                "values": "testdata.Yowza"
+              }
+            ],
+            "default": null
+          },
+          {
+            "name": "string_list_map",
+            "type": [
+              "null",
+              {
+                "type": "map",
+                "values": "testdata.StringList"
+              }
+            ],
+            "default": null
+          },
+          {
+            "name": "string_lists",
+            "type": [
+              "null",
+              {
+                "type": "array",
+                "items": "testdata.StringList"
+              }
+            ],
+            "default": null
+          },
+          {
+            "name": "nested_enum",
+            "type": {
+              "type": "enum",
+              "name": "NestedEnum",
+              "symbols": [
+                "A",
+                "B"
+              ],
+              "default": "A"
+            },
+            "default": "A"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/testdata/nullable_arrays/Yowza.avsc
+++ b/testdata/nullable_arrays/Yowza.avsc
@@ -1,0 +1,12 @@
+{
+  "type": "record",
+  "name": "Yowza",
+  "namespace": "testdata",
+  "fields": [
+    {
+      "name": "hoo_boy",
+      "type": "float",
+      "default": 0
+    }
+  ]
+}


### PR DESCRIPTION
Adding a new feature flag `nullable_arrays` which results in treating repeated fields as optional/nullable arrays.