### PR TITLE
Fix: Wrong default value for records

### DIFF
--- a/avro/field.go
+++ b/avro/field.go
@@ -126,6 +126,8 @@ func DefaultValue(t any) any {
 		return noDefault
 	case "array":
 		return []any{}
+	case "string":
+		return ""
 	}
 
 	switch typedT := t.(type) {
@@ -140,5 +142,5 @@ func DefaultValue(t any) any {
 			return DefaultValue(val)
 	}
 
-	return ""
+	return noDefault
 }

--- a/testdata/base/Foobar.avsc
+++ b/testdata/base/Foobar.avsc
@@ -156,6 +156,10 @@
         "default": "A"
       },
       "default": "A"
+    },
+    {
+      "name": "yowza_again",
+      "type": "testdata.Yowza"
     }
   ]
 }

--- a/testdata/base/Widget.avsc
+++ b/testdata/base/Widget.avsc
@@ -40,8 +40,7 @@
     },
     {
       "name": "strings",
-      "type": "testdata.StringList",
-      "default": ""
+      "type": "testdata.StringList"
     },
     {
       "name": "a_one_of",
@@ -233,6 +232,10 @@
               "default": "A"
             },
             "default": "A"
+          },
+          {
+            "name": "yowza_again",
+            "type": "testdata.Yowza"
           }
         ]
       }

--- a/testdata/collapse_fields/Foobar.avsc
+++ b/testdata/collapse_fields/Foobar.avsc
@@ -150,6 +150,10 @@
         "default": "A"
       },
       "default": "A"
+    },
+    {
+      "name": "yowza_again",
+      "type": "testdata.Yowza"
     }
   ]
 }

--- a/testdata/collapse_fields/Widget.avsc
+++ b/testdata/collapse_fields/Widget.avsc
@@ -233,6 +233,10 @@
               "default": "A"
             },
             "default": "A"
+          },
+          {
+            "name": "yowza_again",
+            "type": "testdata.Yowza"
           }
         ]
       }

--- a/testdata/emit_only/Widget.avsc
+++ b/testdata/emit_only/Widget.avsc
@@ -40,8 +40,7 @@
     },
     {
       "name": "strings",
-      "type": "testdata.StringList",
-      "default": ""
+      "type": "testdata.StringList"
     },
     {
       "name": "a_one_of",
@@ -233,6 +232,10 @@
               "default": "A"
             },
             "default": "A"
+          },
+          {
+            "name": "yowza_again",
+            "type": "testdata.Yowza"
           }
         ]
       }

--- a/testdata/foobar.proto
+++ b/testdata/foobar.proto
@@ -37,4 +37,5 @@ message Foobar {
   map<string, StringList> string_list_map = 14;
   repeated StringList string_lists = 15;
   NestedEnum nested_enum = 16;
+  Yowza yowza_again = 17;
 }

--- a/testdata/json_fieldnames/Foobar.avsc
+++ b/testdata/json_fieldnames/Foobar.avsc
@@ -156,6 +156,10 @@
         "default": "A"
       },
       "default": "A"
+    },
+    {
+      "name": "yowzaAgain",
+      "type": "testdata.Yowza"
     }
   ]
 }

--- a/testdata/json_fieldnames/Widget.avsc
+++ b/testdata/json_fieldnames/Widget.avsc
@@ -40,8 +40,7 @@
     },
     {
       "name": "strings",
-      "type": "testdata.StringList",
-      "default": ""
+      "type": "testdata.StringList"
     },
     {
       "name": "aOneOf",
@@ -233,6 +232,10 @@
               "default": "A"
             },
             "default": "A"
+          },
+          {
+            "name": "yowzaAgain",
+            "type": "testdata.Yowza"
           }
         ]
       }

--- a/testdata/namespace_map/Foobar.avsc
+++ b/testdata/namespace_map/Foobar.avsc
@@ -156,6 +156,10 @@
         "default": "A"
       },
       "default": "A"
+    },
+    {
+      "name": "yowza_again",
+      "type": "mynamespace.Yowza"
     }
   ]
 }

--- a/testdata/namespace_map/Widget.avsc
+++ b/testdata/namespace_map/Widget.avsc
@@ -40,8 +40,7 @@
     },
     {
       "name": "strings",
-      "type": "mynamespace.StringList",
-      "default": ""
+      "type": "mynamespace.StringList"
     },
     {
       "name": "a_one_of",
@@ -233,6 +232,10 @@
               "default": "A"
             },
             "default": "A"
+          },
+          {
+            "name": "yowza_again",
+            "type": "mynamespace.Yowza"
           }
         ]
       }

--- a/testdata/nullable_arrays/Foobar.avsc
+++ b/testdata/nullable_arrays/Foobar.avsc
@@ -183,6 +183,10 @@
         "default": "A"
       },
       "default": "A"
+    },
+    {
+      "name": "yowza_again",
+      "type": "testdata.Yowza"
     }
   ]
 }

--- a/testdata/nullable_arrays/Widget.avsc
+++ b/testdata/nullable_arrays/Widget.avsc
@@ -46,8 +46,7 @@
     },
     {
       "name": "strings",
-      "type": "testdata.StringList",
-      "default": ""
+      "type": "testdata.StringList"
     },
     {
       "name": "a_one_of",
@@ -263,6 +262,10 @@
               "default": "A"
             },
             "default": "A"
+          },
+          {
+            "name": "yowza_again",
+            "type": "testdata.Yowza"
           }
         ]
       }

--- a/testdata/prefix_schema_files_with_package/testdata/Foobar.avsc
+++ b/testdata/prefix_schema_files_with_package/testdata/Foobar.avsc
@@ -156,6 +156,10 @@
         "default": "A"
       },
       "default": "A"
+    },
+    {
+      "name": "yowza_again",
+      "type": "testdata.Yowza"
     }
   ]
 }

--- a/testdata/prefix_schema_files_with_package/testdata/Widget.avsc
+++ b/testdata/prefix_schema_files_with_package/testdata/Widget.avsc
@@ -40,8 +40,7 @@
     },
     {
       "name": "strings",
-      "type": "testdata.StringList",
-      "default": ""
+      "type": "testdata.StringList"
     },
     {
       "name": "a_one_of",
@@ -233,6 +232,10 @@
               "default": "A"
             },
             "default": "A"
+          },
+          {
+            "name": "yowza_again",
+            "type": "testdata.Yowza"
           }
         ]
       }

--- a/testdata/preserve_non_string_maps/Foobar.avsc
+++ b/testdata/preserve_non_string_maps/Foobar.avsc
@@ -122,8 +122,7 @@
             },
             {
               "name": "value",
-              "type": "testdata.Yowza",
-              "default": ""
+              "type": "testdata.Yowza"
             }
           ]
         }
@@ -172,6 +171,10 @@
         "default": "A"
       },
       "default": "A"
+    },
+    {
+      "name": "yowza_again",
+      "type": "testdata.Yowza"
     }
   ]
 }

--- a/testdata/preserve_non_string_maps/Widget.avsc
+++ b/testdata/preserve_non_string_maps/Widget.avsc
@@ -40,8 +40,7 @@
     },
     {
       "name": "strings",
-      "type": "testdata.StringList",
-      "default": ""
+      "type": "testdata.StringList"
     },
     {
       "name": "a_one_of",
@@ -213,8 +212,7 @@
                   },
                   {
                     "name": "value",
-                    "type": "testdata.Yowza",
-                    "default": ""
+                    "type": "testdata.Yowza"
                   }
                 ]
               }
@@ -249,6 +247,10 @@
               "default": "A"
             },
             "default": "A"
+          },
+          {
+            "name": "yowza_again",
+            "type": "testdata.Yowza"
           }
         ]
       }

--- a/testdata/retain_oneof_fieldnames/Foobar.avsc
+++ b/testdata/retain_oneof_fieldnames/Foobar.avsc
@@ -156,6 +156,10 @@
         "default": "A"
       },
       "default": "A"
+    },
+    {
+      "name": "yowza_again",
+      "type": "testdata.Yowza"
     }
   ]
 }

--- a/testdata/retain_oneof_fieldnames/Widget.avsc
+++ b/testdata/retain_oneof_fieldnames/Widget.avsc
@@ -40,8 +40,7 @@
     },
     {
       "name": "strings",
-      "type": "testdata.StringList",
-      "default": ""
+      "type": "testdata.StringList"
     },
     {
       "name": "a_one_of",
@@ -241,6 +240,10 @@
               "default": "A"
             },
             "default": "A"
+          },
+          {
+            "name": "yowza_again",
+            "type": "testdata.Yowza"
           }
         ]
       }

--- a/testdata/retain_oneof_fieldnames_json_fieldnames/Foobar.avsc
+++ b/testdata/retain_oneof_fieldnames_json_fieldnames/Foobar.avsc
@@ -156,6 +156,10 @@
         "default": "A"
       },
       "default": "A"
+    },
+    {
+      "name": "yowzaAgain",
+      "type": "testdata.Yowza"
     }
   ]
 }

--- a/testdata/retain_oneof_fieldnames_json_fieldnames/Widget.avsc
+++ b/testdata/retain_oneof_fieldnames_json_fieldnames/Widget.avsc
@@ -40,8 +40,7 @@
     },
     {
       "name": "strings",
-      "type": "testdata.StringList",
-      "default": ""
+      "type": "testdata.StringList"
     },
     {
       "name": "aOneOf",
@@ -241,6 +240,10 @@
               "default": "A"
             },
             "default": "A"
+          },
+          {
+            "name": "yowzaAgain",
+            "type": "testdata.Yowza"
           }
         ]
       }


### PR DESCRIPTION
Fixed a bug where the default value for a record referenced again is set to an empty string instead of no default.